### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # Tor
 
-Publisher: Splunk \
-Connector Version: 2.0.4 \
-Product Vendor: Tor \
-Product Name: Tor \
+Publisher: Splunk <br>
+Connector Version: 2.0.4 <br>
+Product Vendor: Tor <br>
+Product Name: Tor <br>
 Minimum Product Version: 5.1.0
 
 This app implements investigative actions to query info about the Tor network
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validates the connection to the Tor Project website \
+[test connectivity](#action-test-connectivity) - Validates the connection to the Tor Project website <br>
 [lookup ip](#action-lookup-ip) - Check if IP is a Tor exit node
 
 ## action: 'test connectivity'
 
 Validates the connection to the Tor Project website
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -32,7 +32,7 @@ No Output
 
 Check if IP is a Tor exit node
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 Download a list of current exit nodes to determine if an IP is an exit node. During each action run, if the current list is found to be downloaded over 30 minutes ago, it will download an updated version.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Resolved app issues related to Python 3.13 upgrade
+* Update Python version for 3.13

--- a/tor.json
+++ b/tor.json
@@ -130,5 +130,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/tor.json
+++ b/tor.json
@@ -16,7 +16,7 @@
     "main_module": "tor_connector.py",
     "min_phantom_version": "5.1.0",
     "fips_compliant": true,
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "latest_tested_versions": [
         "On local cloud, tested on 1st June 2021"
     ],


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)